### PR TITLE
Accessible XSL-FO PDF examples on the Examples page

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -91,6 +91,12 @@ DEBUG=1
 #     in the  scripts/pretext-format  directory of the website
 #     repository.  This in turn requires having  npm  for
 #     installation, and  node  for use.
+#
+# 6.  The "pdf-fo" format (an experimental, LaTeX-free route to an
+#     accessible PDF via XSL-FO) is rendered by the Apache FOP
+#     processor, which must be installed.  On Debian:
+#
+#         apt install fop
 
 #######################
 # Temporary Directories
@@ -156,6 +162,7 @@ declare SBST=structural
 declare SA=${PTX}/examples/sample-article
 declare SB=${PTX}/examples/sample-book
 declare WW=${PTX}/examples/webwork/sample-chapter
+declare PFD=${PTX}/examples/pdf-fo-development
 declare G=${PTX}/doc/guide
 declare ES=${PTX}/examples/epub
 declare SLP=${PTX}/schema
@@ -307,6 +314,10 @@ install -d ${EXAMPLESOUT}/sample-article/html
 ${PTXPTX} -v -c doc -f pdf -d ${EXAMPLESOUT}/sample-article -p ${SA}/publication.xml ${SA}/sample-article.xml
 # PDF - print, with outfile name change
 ${PTXPTX} -v -c doc -f pdf -o ${EXAMPLESOUT}/sample-article/sample-article-print.pdf -p ${SA}/publication-print.xml ${SA}/sample-article.xml
+# PDF - accessible, via XSL-FO and Apache FOP, with outfile name change
+# (very experimental, but with full PDF/UA-1 coverage).  Requires the
+# Apache FOP processor (Debian package:  fop)
+${PTXPTX} -v -c doc -f pdf-fo -o ${EXAMPLESOUT}/sample-article/sample-article-fo.pdf -p ${SA}/publication.xml ${SA}/sample-article.xml
 # HTML
 ${PTXPTX} -v -c doc -f html -d ${EXAMPLESOUT}/sample-article/html -p ${SA}/publication.xml ${SA}/sample-article.xml
 
@@ -349,6 +360,25 @@ cd -
 cd ${SCRATCH}/sa/annotated/sample-article
 ${PTXPTX} -v -c doc -f html -x debug.html.annotate yes -d ${EXAMPLESOUT}/sample-article/annotated -p publication.xml sample-article.xml
 cd -
+
+# FO test development article
+echo
+echo "BUILD: creating FO test development article :BUILD"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+# The development document for the "pdf-fo" format: a LaTeX-free,
+# accessible PDF rendered through XSL-FO by Apache FOP.  We build
+# the same source three ways (the accessible FO PDF, a regular
+# LaTeX PDF, and HTML) for side-by-side comparison.  The "pdf-fo"
+# format requires the Apache FOP processor (Debian package:  fop)
+install -d ${EXAMPLESOUT}/pdf-fo-development/html
+# PDF - accessible, via XSL-FO and Apache FOP (the default outfile
+# name is the headline product)
+${PTXPTX} -v -c doc -f pdf-fo -d ${EXAMPLESOUT}/pdf-fo-development -p ${PFD}/publication.xml ${PFD}/pdf-fo-development.xml
+# PDF - regular (LaTeX), outfile renamed so it does not collide
+# with the FO PDF above
+${PTXPTX} -v -c doc -f pdf -o ${EXAMPLESOUT}/pdf-fo-development/pdf-fo-development-latex.pdf -p ${PFD}/publication.xml ${PFD}/pdf-fo-development.xml
+# HTML
+${PTXPTX} -v -c doc -f html -d ${EXAMPLESOUT}/pdf-fo-development/html -p ${PFD}/publication.xml ${PFD}/pdf-fo-development.xml
 
 # Sample book
 echo

--- a/site/pages/examples.md
+++ b/site/pages/examples.md
@@ -53,7 +53,19 @@ But it is cutting-edge and contains new features before they make it into the Au
 - [Sample Article, Annotated](examples/sample-article/annotated)
 - [Sample Article, Electronic PDF (one-sided)](examples/sample-article/sample-article.pdf)
 - [Sample Article, Print PDF (two-sided)](examples/sample-article/sample-article-print.pdf)
+- [Sample Article, Accessible PDF via XSL-FO](examples/sample-article/sample-article-fo.pdf) (<em>very</em> experimental, but with full PDF/UA-1 accessibility coverage)
 - [Sample Article, Source at GitHub](https://github.com/PreTeXtBook/pretext/tree/master/examples/sample-article)
+
+### Accessible PDF via XSL Formatting Objects
+
+This small article is the development sandbox for an <em>experimental</em>, LaTeX-free route to PDF.  Rather than passing through LaTeX, the PreTeXt source is converted to XSL Formatting Objects (XSL-FO) and rendered by the [Apache FOP](https://xmlgraphics.apache.org/fop/) processor.  Mathematics is set with MathJax (as SVG), and the resulting PDF is <em>accessible by default</em>: it is a tagged PDF conforming to PDF/UA-1 (ISO&nbsp;14289-1, the accessibility standard), with a heading outline, alternate text for images and mathematics, document metadata, and a logical reading order built in from the start.
+
+The same source is built three ways below, so the accessible FO PDF can be compared against a traditional LaTeX PDF and the online HTML.  This route is new and still incomplete, so expect some rough edges.
+
+- [Development Article, Accessible PDF via XSL-FO](examples/pdf-fo-development/pdf-fo-development.pdf)
+- [Development Article, Online](examples/pdf-fo-development/html)
+- [Development Article, Regular (LaTeX) PDF](examples/pdf-fo-development/pdf-fo-development-latex.pdf)
+- [Development Article, Source at GitHub](https://github.com/PreTeXtBook/pretext/tree/master/examples/pdf-fo-development)
 
 ### WeBWorK Sample Chapter
 


### PR DESCRIPTION
Adds website builds and links for the new LaTeX-free, accessible PDF route (XSL-FO via Apache FOP), now merged into PreTeXt `master`.

- **Script:** builds accessible XSL-FO PDFs of two examples — the Sample Article (alongside its existing electronic and print PDFs) and the new FO development article (built three ways: accessible FO PDF, regular LaTeX PDF, and HTML, for side-by-side comparison). Adds a prerequisite note that the `pdf-fo` format is rendered by the Apache FOP processor (Debian: `apt install fop`).
- **Pages:** links the Sample Article FO PDF (flagged *very* experimental, with full PDF/UA-1 coverage), and adds an "Accessible PDF via XSL Formatting Objects" section presenting the development article's three builds, accessible FO PDF first.

Opened for the record; to be merged locally.

---
*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
